### PR TITLE
Improve readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The first time you set up, you should install the required npm packages:
 npm install
 ```
 
+You should also create a '.env' file with the following fields:
+```
+SERVER_ADDRESS = <the URL where a server is currently running>
+```
+*Tip: Copypasting/renaming '.env.template' file should be enough for a default/local setup*
 
 Then run the watch (to auto-rebuild sass and js on each change):
 ```

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ Using https://github.com/maxogden/voxel-engine (awesome stuff!).
 
 ## Get it running on your machine
 
-The first time you set up, you should install the required npm packages:
+1) Install npm dependencies (first time only):
 
 ```
 npm install
 ```
 
-You should also create a '.env' file with the following fields:
+2) You should also create an '.env' file with the following fields:
 ```
 SERVER_ADDRESS = <the URL where a server is currently running>
 ```
 *Tip: Copypasting/renaming '.env.template' file should be enough for a default/local setup*
 
-Then run the watch (to auto-rebuild sass and js on each change):
+3) Run + watch (to auto-rebuild sass and js on each change):
 ```
 npm run watch
 ```
 
-Then point your browser to `http://localhost:1337` and have fun!
+4) Navigate to `http://localhost:1337` and have fun!
 
 ## Controls
 - When you start, click on the page to lock cursor. Press `<ESC>` to unlock cursor.


### PR DESCRIPTION
1) Adding .env file requirement to README.md file 

2) Improving readability based on my own opinion (feel free to exclude/review this commit if desired)

However, IMHO, for better usability/readability, I think it the '.env' config, and optional 'watch' part should be written in a separate section from the minimum setup requirements, which would just be:

> npm install
> npm start

Going one step further, wouldn't it be better to have the '.env' file created by default? (or just rename '.env.template' to '.env'?)
